### PR TITLE
Add libhybris to the cmake build system

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -56,6 +56,7 @@ if(UNIX)
     option(ENABLE_X11         "Enable X11 support?" ON)
     option(ENABLE_AML         "Enable AML?" OFF)
     option(ENABLE_IMX         "Enable IMX?" OFF)
+    option(ENABLE_HYBRIS      "Enable libhybris?" OFF)
   endif()
 endif()
 # System options
@@ -118,6 +119,11 @@ endif()
 set(optional_deps LCMS2 MicroHttpd MySqlClient SSH XSLT
                   Alsa UDEV DBus Avahi SmbClient CCache
                   PulseAudio VDPAU VAAPI Bluetooth CAP)
+
+# Add libhybris if needed
+if(ENABLE_HYBRIS)
+  list(APPEND optional_deps Hybris)
+endif()
 
 # Required, dyloaded deps
 set(required_dyload Curl ASS)

--- a/project/cmake/modules/FindHybris.cmake
+++ b/project/cmake/modules/FindHybris.cmake
@@ -1,0 +1,24 @@
+#.rst:
+# FindHybris
+# ------------
+# Finds libhybris
+#
+# This will define the following variables::
+#
+# HYBRIS_FOUND - system has libhybris
+# HYRBIS_INCLUDE_DIRS - the libhybris include directories
+# HYBRIS_LIBRARIES - the libhybris libraries
+# HYBRIS_DEFINITIONS - the libhybris definitions
+
+if(NOT UNIX)
+  message(FATAL_ERROR "libhybris is only available on Linux")
+endif()
+
+set(HYBRIS_DEFINITIONS -DTARGET_POSIX -DTARGET_LINUX -D_LINUX -DTARGET_HYBRIS -DHAS_HYBRIS)
+
+pkg_check_modules(HYBRIS REQUIRED hwcomposer-egl>=0.1 hybris-egl-platform>=0.1 libhardware>=0.1 libsync>=0.1)
+
+# NOTE: The following might be wrong if libhybris is not set up in the default
+# location, but some files include files from the root of libhybris includes,
+# so we must at least try to include libhybris's include root
+list(APPEND HYBRIS_INCLUDE_DIRS /usr/include/hybris)

--- a/xbmc/windowing/egl/CMakeLists.txt
+++ b/xbmc/windowing/egl/CMakeLists.txt
@@ -8,6 +8,10 @@ if(OPENGLES_FOUND OR AML_FOUND OR IMX_FOUND OR MMAL_FOUND)
               EGLNativeTypeFbdev.h)
 endif()
 
+if(HYBRIS_FOUND)
+  list(APPEND SOURCES EGLNativeTypeHybris.cpp)
+endif()
+
 if(OPENGLES_FOUND)
   list(APPEND SOURCES WinSystemEGL.cpp)
   list(APPEND HEADERS WinSystemEGL.h)


### PR DESCRIPTION
Add the `ENABLE_HYBRIS` flag to the cmake options, which can be used to compile kodi with libhybris support. Tested successfully on my Odroid-XU with MFC. 🎉 

I worked with the 17.4rc release, so you also get a free upgrade in this PR. 😄