### PR TITLE
Some improvements for U2/U3

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19787,3 +19787,15 @@ msgstr ""
 msgctxt "#39010"
 msgid "Select sort method"
 msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#99998"
+msgid "Allow hardware acceleration - MFC"
+msgstr ""
+
+#. Description of setting "Videos -> Playback -> Allow hardware acceleration (MFC)" with label #99999
+#: system/settings/settings.xml
+msgctxt "#99999"
+msgid "Enable hardware video decode using MFC decoder."
+msgstr ""
+

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -99,6 +99,15 @@
             <formatlabel>14047</formatlabel>
           </control>
         </setting>
+        <setting id="videoplayer.usemfc" type="boolean" label="99998" help="99999">
+          <requirement>HAVE_MFC</requirement>
+          <level>2</level>
+          <default>true</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.useamcodec" type="boolean" label="13438" help="36422">
           <requirement>HAVE_AMCODEC</requirement>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -153,7 +153,8 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
 #elif defined(HAS_MMAL)
     pCodec = OpenCodec(new CMMALVideo(processInfo), hint, options);
 #elif defined(HAS_MFC)
-    pCodec = OpenCodec(new CDVDVideoCodecMFC(processInfo), hint, options);
+    if (CSettings::GetInstance().GetBool("videoplayer.usemfc"))
+      pCodec = OpenCodec(new CDVDVideoCodecMFC(processInfo), hint, options);
 #endif
     if (pCodec)
       return pCodec;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(SOURCES DVDFactoryInputStream.cpp
             DVDInputStream.cpp
             DVDInputStreamFFmpeg.cpp

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -327,6 +327,9 @@ void CSettingConditions::Initialize()
 #ifdef TARGET_DARWIN
   m_simpleConditions.insert("HasVTB");
 #endif
+#ifdef HAS_MFC
+  m_simpleConditions.insert("have_mfc");
+#endif
 #ifdef HAS_LIBAMCODEC
   if (aml_present())
     m_simpleConditions.insert("have_amcodec");

--- a/xbmc/windowing/X11/CMakeLists.txt
+++ b/xbmc/windowing/X11/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 set(SOURCES GLContextEGL.cpp
             GLContextGLX.cpp
             GLContext.cpp

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -23,6 +23,7 @@
 #if defined(HAVE_X11)
 #include "GLContext.h"
 #include "EGL/egl.h"
+#include <X11/Xutil.h>
 
 class CGLContextEGL : public CGLContext
 {


### PR DESCRIPTION
Hello Owersun,
I finally got the motivations to commit the little modifications I made on Kodi for myself.

First patch was needed for me to build it on U2.
Second patch adds a MFC toggle which replace the old "Enable Hardware decoding" (or something like that) option which was removed upstream some releases ago.
I really have better results on the U2 with Software Decoding. Hardware Decoding only provides me better result with "textbook" high bitrate FHD movies.

Feel free to merge or discuss this PR if you're interested in it. I'm a noob at coding so some things may be wrong...